### PR TITLE
Allow overriding of BASETYPE_FIELD_MAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ It may define the following module-level variables:
   * `methods` - a list of strings that are included as methods in the generated model class, e.g.:
     ```python
     'methods': [
-        '    def __unicode__(self): return "%s: %s" % (self.code, self.amount)', 
+        '    def __unicode__(self): return "%s: %s" % (self.code, self.amount)',
     ],
     ```
   * `null_fields` - a `list` of field names for which `null=True` Django model field option should be enforced.
@@ -159,6 +159,13 @@ It may define the following module-level variables:
       'xs:IDREF': ('A reference to xs:ID', 'CharField', {'max_length': 64}),
   }
   ```
+
+* `BASETYPE_OVERRIDES` is a `dict` mapping XSD type names to Django field to override default ones e.g.:
+```python
+BASETYPE_OVERRIDES = {
+    'xs:hexBinary': 'CharField',
+}
+```
 
 * `IMPORTS` is a string inserted after the automatically generated `import`s in the output models file, e.g.:
    ```python

--- a/xsd_to_django_model/xsd_to_django_model.py
+++ b/xsd_to_django_model/xsd_to_django_model.py
@@ -82,6 +82,7 @@ BASETYPE_FIELD_MAP = {
     'xs:string': 'CharField',
     'xs:token': 'CharField',
     'xs:unsignedInt': 'BigIntegerField',
+    'xs:hexBinary': 'CharField',
 }
 NS = {'xs': "http://www.w3.org/2001/XMLSchema"}
 

--- a/xsd_to_django_model/xsd_to_django_model.py
+++ b/xsd_to_django_model/xsd_to_django_model.py
@@ -73,6 +73,7 @@ BASETYPE_FIELD_MAP = {
     'xs:decimal': 'DecimalField',
     'xs:double': 'FloatField',
     'xs:gYearMonth': 'DateField',  # Really YYYY-MM
+    'xs:hexBinary': 'BinaryField',
     'xs:int': 'IntegerField',
     'xs:integer': 'IntegerField',
     'xs:long': 'BigIntegerField',
@@ -82,7 +83,6 @@ BASETYPE_FIELD_MAP = {
     'xs:string': 'CharField',
     'xs:token': 'CharField',
     'xs:unsignedInt': 'BigIntegerField',
-    'xs:hexBinary': 'CharField',
 }
 NS = {'xs': "http://www.w3.org/2001/XMLSchema"}
 

--- a/xsd_to_django_model/xsd_to_django_model.py
+++ b/xsd_to_django_model/xsd_to_django_model.py
@@ -55,6 +55,10 @@ try:
 except ImportError:
     TYPE_OVERRIDES = {}
 try:
+    from xsd_to_django_model_settings import BASETYPE_OVERRIDES
+except ImportError:
+    BASETYPE_OVERRIDES = {}
+try:
     from xsd_to_django_model_settings import IMPORTS
 except ImportError:
     IMPORTS = ''
@@ -84,6 +88,9 @@ BASETYPE_FIELD_MAP = {
     'xs:token': 'CharField',
     'xs:unsignedInt': 'BigIntegerField',
 }
+
+BASETYPE_FIELD_MAP.update(BASETYPE_OVERRIDES)
+
 NS = {'xs': "http://www.w3.org/2001/XMLSchema"}
 
 FIELD_TMPL = {


### PR DESCRIPTION
Add option `BASETYPE_OVERRIDES` in xsd_to_django_model_settings.py to allow overriding the mapping of xsd base type to Django model fields.